### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ env:
 jobs:
   publish:
     name: Publish 🚀
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code 📚


### PR DESCRIPTION
Potential fix for [https://github.com/JanSzewczyk/prettier-config/security/code-scanning/13](https://github.com/JanSzewczyk/prettier-config/security/code-scanning/13)

To address the problem, add a `permissions` block to the workflow (or at the job level) that grants only the minimum required privileges. Since the workflow uses `npx semantic-release` to publish, it requires write access to the repository contents (`contents: write`). This permission allows release tags and GitHub release notes to be created or updated, which is standard for such workflows. Place the `permissions` key directly under the `publish` job definition (indented to match the job's keys, above `runs-on`). No functionality will be changed except for tightening the security posture of the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
